### PR TITLE
SwiLex empty and eof tokens supported

### DIFF
--- a/Sources/SwiLex/SwiLex.swift
+++ b/Sources/SwiLex/SwiLex.swift
@@ -74,7 +74,8 @@ public struct SwiLex<Tokens: SwiLexable> {
             scanner.move(to: longestMatchIndex)
             scanner.removeSeparators()
         }
-
+        let end = Token(type: Tokens.eof, value: "")
+        stream.append(end)
         return stream
     }
 }

--- a/Sources/SwiLex/SwiLexable.swift
+++ b/Sources/SwiLex/SwiLexable.swift
@@ -10,10 +10,13 @@ import Foundation
 
 // MARK: Public interface
 
-/// A type of tokens that can be used to **lex** an input string using **SwiLex**.
-public protocol SwiLexable: RawRepresentable, CaseIterable where Self.RawValue == String {
+/// A type of tokens that can be used to **lex** an input string using **SwiLex** (terminal tokens).
+public protocol SwiLexable: Hashable, RawRepresentable, CaseIterable where Self.RawValue == String {
     /// Possible modes while Lexing.
     associatedtype Mode: Hashable = AnyHashable
+
+    static var eof: Self { get }
+    static var none: Self { get }
 
     /// Characters used as sparators.
     ///

--- a/Tests/SwiLexTests/CalculatorTokensTests.swift
+++ b/Tests/SwiLexTests/CalculatorTokensTests.swift
@@ -9,6 +9,9 @@ final class CalculatorTokensTests: XCTestCase {
         case int = "[0-9]+"
         case lParenthesis = #"\("#
         case rParenthesis = #"\)"#
+
+        case eof
+        case none
     }
 
     func testIntSum() throws {
@@ -16,9 +19,10 @@ final class CalculatorTokensTests: XCTestCase {
         let tokens = try lexer.lex(input: "1 + 1")
         AssertEqualTokens(tokens1: tokens,
                           tokens2: [
-                              Token<CalculatorTokens>(type: .int, value: "1"),
-                              Token<CalculatorTokens>(type: .op, value: "+"),
-                              Token<CalculatorTokens>(type: .int, value: "1"),
+                            Token<CalculatorTokens>(type: .int, value: "1"),
+                            Token<CalculatorTokens>(type: .op, value: "+"),
+                            Token<CalculatorTokens>(type: .int, value: "1"),
+                            Token<CalculatorTokens>(type: .eof, value: ""),
                           ])
     }
 
@@ -27,9 +31,10 @@ final class CalculatorTokensTests: XCTestCase {
         let tokens = try lexer.lex(input: "1.2   +      1.004")
         AssertEqualTokens(tokens1: tokens,
                           tokens2: [
-                              Token<CalculatorTokens>(type: .float, value: "1.2"),
-                              Token<CalculatorTokens>(type: .op, value: "+"),
-                              Token<CalculatorTokens>(type: .float, value: "1.004"),
+                            Token<CalculatorTokens>(type: .float, value: "1.2"),
+                            Token<CalculatorTokens>(type: .op, value: "+"),
+                            Token<CalculatorTokens>(type: .float, value: "1.004"),
+                            Token<CalculatorTokens>(type: .eof, value: ""),
                           ])
     }
 
@@ -38,9 +43,10 @@ final class CalculatorTokensTests: XCTestCase {
         let tokens = try lexer.lex(input: "   1332.4322  +       1   ")
         AssertEqualTokens(tokens1: tokens,
                           tokens2: [
-                              Token<CalculatorTokens>(type: .float, value: "1332.4322"),
-                              Token<CalculatorTokens>(type: .op, value: "+"),
-                              Token<CalculatorTokens>(type: .int, value: "1"),
+                            Token<CalculatorTokens>(type: .float, value: "1332.4322"),
+                            Token<CalculatorTokens>(type: .op, value: "+"),
+                            Token<CalculatorTokens>(type: .int, value: "1"),
+                            Token<CalculatorTokens>(type: .eof, value: ""),
                           ])
     }
 
@@ -50,27 +56,28 @@ final class CalculatorTokensTests: XCTestCase {
         print(tokens)
         AssertEqualTokens(tokens1: tokens,
                           tokens2: [
-                              Token<CalculatorTokens>(type: .lParenthesis, value: "("),
-                              Token<CalculatorTokens>(type: .float, value: "1332.4322"),
-                              Token<CalculatorTokens>(type: .op, value: "+"),
-                              Token<CalculatorTokens>(type: .int, value: "1"),
-                              Token<CalculatorTokens>(type: .rParenthesis, value: ")"),
-                              Token<CalculatorTokens>(type: .op, value: "*"),
-                              Token<CalculatorTokens>(type: .int, value: "2"),
-                              Token<CalculatorTokens>(type: .op, value: "/"),
-                              Token<CalculatorTokens>(type: .float, value: "44.44"),
-                              Token<CalculatorTokens>(type: .op, value: "+"),
-                              Token<CalculatorTokens>(type: .lParenthesis, value: "("),
-                              Token<CalculatorTokens>(type: .lParenthesis, value: "("),
-                              Token<CalculatorTokens>(type: .float, value: "2.3"),
-                              Token<CalculatorTokens>(type: .op, value: "-"),
-                              Token<CalculatorTokens>(type: .int, value: "2"),
-                              Token<CalculatorTokens>(type: .rParenthesis, value: ")"),
-                              Token<CalculatorTokens>(type: .op, value: "*"),
-                              Token<CalculatorTokens>(type: .int, value: "4"),
-                              Token<CalculatorTokens>(type: .rParenthesis, value: ")"),
-                              Token<CalculatorTokens>(type: .op, value: "/"),
-                              Token<CalculatorTokens>(type: .float, value: "0.3"),
+                            Token<CalculatorTokens>(type: .lParenthesis, value: "("),
+                            Token<CalculatorTokens>(type: .float, value: "1332.4322"),
+                            Token<CalculatorTokens>(type: .op, value: "+"),
+                            Token<CalculatorTokens>(type: .int, value: "1"),
+                            Token<CalculatorTokens>(type: .rParenthesis, value: ")"),
+                            Token<CalculatorTokens>(type: .op, value: "*"),
+                            Token<CalculatorTokens>(type: .int, value: "2"),
+                            Token<CalculatorTokens>(type: .op, value: "/"),
+                            Token<CalculatorTokens>(type: .float, value: "44.44"),
+                            Token<CalculatorTokens>(type: .op, value: "+"),
+                            Token<CalculatorTokens>(type: .lParenthesis, value: "("),
+                            Token<CalculatorTokens>(type: .lParenthesis, value: "("),
+                            Token<CalculatorTokens>(type: .float, value: "2.3"),
+                            Token<CalculatorTokens>(type: .op, value: "-"),
+                            Token<CalculatorTokens>(type: .int, value: "2"),
+                            Token<CalculatorTokens>(type: .rParenthesis, value: ")"),
+                            Token<CalculatorTokens>(type: .op, value: "*"),
+                            Token<CalculatorTokens>(type: .int, value: "4"),
+                            Token<CalculatorTokens>(type: .rParenthesis, value: ")"),
+                            Token<CalculatorTokens>(type: .op, value: "/"),
+                            Token<CalculatorTokens>(type: .float, value: "0.3"),
+                            Token<CalculatorTokens>(type: .eof, value: ""),
                           ])
     }
 

--- a/Tests/SwiLexTests/WordNumberTokensTests.swift
+++ b/Tests/SwiLexTests/WordNumberTokensTests.swift
@@ -6,6 +6,9 @@ final class WordNumberTokensTests: XCTestCase {
         static var separators: Set<Character> = [" ", "\n"]
         case txt = "[A-Za-z]*"
         case number = "[0-9]*"
+        
+        case eof
+        case none
     }
 
     func testWords() throws {
@@ -13,15 +16,16 @@ final class WordNumberTokensTests: XCTestCase {
         let tokens = try lexer.lex(input: "  HELLO  h i abc  ABC   Hi   hello         boy        XD")
         AssertEqualTokens(tokens1: tokens,
                           tokens2: [
-                              Token<WordNumberTokens>(type: .txt, value: "HELLO"),
-                              Token<WordNumberTokens>(type: .txt, value: "h"),
-                              Token<WordNumberTokens>(type: .txt, value: "i"),
-                              Token<WordNumberTokens>(type: .txt, value: "abc"),
-                              Token<WordNumberTokens>(type: .txt, value: "ABC"),
-                              Token<WordNumberTokens>(type: .txt, value: "Hi"),
-                              Token<WordNumberTokens>(type: .txt, value: "hello"),
-                              Token<WordNumberTokens>(type: .txt, value: "boy"),
-                              Token<WordNumberTokens>(type: .txt, value: "XD"),
+                            Token<WordNumberTokens>(type: .txt, value: "HELLO"),
+                            Token<WordNumberTokens>(type: .txt, value: "h"),
+                            Token<WordNumberTokens>(type: .txt, value: "i"),
+                            Token<WordNumberTokens>(type: .txt, value: "abc"),
+                            Token<WordNumberTokens>(type: .txt, value: "ABC"),
+                            Token<WordNumberTokens>(type: .txt, value: "Hi"),
+                            Token<WordNumberTokens>(type: .txt, value: "hello"),
+                            Token<WordNumberTokens>(type: .txt, value: "boy"),
+                            Token<WordNumberTokens>(type: .txt, value: "XD"),
+                            Token<WordNumberTokens>(type: .eof, value: ""),
                           ])
     }
 
@@ -30,14 +34,15 @@ final class WordNumberTokensTests: XCTestCase {
         let tokens = try lexer.lex(input: "  233 2    1  23123    3333333     324    33    2")
         AssertEqualTokens(tokens1: tokens,
                           tokens2: [
-                              Token<WordNumberTokens>(type: .number, value: "233"),
-                              Token<WordNumberTokens>(type: .number, value: "2"),
-                              Token<WordNumberTokens>(type: .number, value: "1"),
-                              Token<WordNumberTokens>(type: .number, value: "23123"),
-                              Token<WordNumberTokens>(type: .number, value: "3333333"),
-                              Token<WordNumberTokens>(type: .number, value: "324"),
-                              Token<WordNumberTokens>(type: .number, value: "33"),
-                              Token<WordNumberTokens>(type: .number, value: "2"),
+                            Token<WordNumberTokens>(type: .number, value: "233"),
+                            Token<WordNumberTokens>(type: .number, value: "2"),
+                            Token<WordNumberTokens>(type: .number, value: "1"),
+                            Token<WordNumberTokens>(type: .number, value: "23123"),
+                            Token<WordNumberTokens>(type: .number, value: "3333333"),
+                            Token<WordNumberTokens>(type: .number, value: "324"),
+                            Token<WordNumberTokens>(type: .number, value: "33"),
+                            Token<WordNumberTokens>(type: .number, value: "2"),
+                            Token<WordNumberTokens>(type: .eof, value: ""),
                           ])
     }
 
@@ -46,17 +51,18 @@ final class WordNumberTokensTests: XCTestCase {
         let tokens = try lexer.lex(input: "  233 2    1  23123abc  ABC   Hi3333333     324    33    2")
         AssertEqualTokens(tokens1: tokens,
                           tokens2: [
-                              Token<WordNumberTokens>(type: .number, value: "233"),
-                              Token<WordNumberTokens>(type: .number, value: "2"),
-                              Token<WordNumberTokens>(type: .number, value: "1"),
-                              Token<WordNumberTokens>(type: .number, value: "23123"),
-                              Token<WordNumberTokens>(type: .txt, value: "abc"),
-                              Token<WordNumberTokens>(type: .txt, value: "ABC"),
-                              Token<WordNumberTokens>(type: .txt, value: "Hi"),
-                              Token<WordNumberTokens>(type: .number, value: "3333333"),
-                              Token<WordNumberTokens>(type: .number, value: "324"),
-                              Token<WordNumberTokens>(type: .number, value: "33"),
-                              Token<WordNumberTokens>(type: .number, value: "2"),
+                            Token<WordNumberTokens>(type: .number, value: "233"),
+                            Token<WordNumberTokens>(type: .number, value: "2"),
+                            Token<WordNumberTokens>(type: .number, value: "1"),
+                            Token<WordNumberTokens>(type: .number, value: "23123"),
+                            Token<WordNumberTokens>(type: .txt, value: "abc"),
+                            Token<WordNumberTokens>(type: .txt, value: "ABC"),
+                            Token<WordNumberTokens>(type: .txt, value: "Hi"),
+                            Token<WordNumberTokens>(type: .number, value: "3333333"),
+                            Token<WordNumberTokens>(type: .number, value: "324"),
+                            Token<WordNumberTokens>(type: .number, value: "33"),
+                            Token<WordNumberTokens>(type: .number, value: "2"),
+                            Token<WordNumberTokens>(type: .eof, value: ""),
                           ])
     }
 


### PR DESCRIPTION
SwiLex now supports `.none` for empty tokens and `.eof` for the end of the input string.